### PR TITLE
Replace body parser middleware with express's own.

### DIFF
--- a/open_cx_server/app.js
+++ b/open_cx_server/app.js
@@ -2,7 +2,6 @@
 
 require('dotenv/config');
 
-const bodyParser = require('body-parser');
 const mongoose = require('mongoose');
 const OPTS = { useUnifiedTopology: true, useNewUrlParser: true };
 const express = require('express');
@@ -15,7 +14,8 @@ const routes = require('./routes');
 
 // Middlewares
 app.use('/admin', require('./admin'))
-app.use(bodyParser.json());
+app.use(express.json());
+app.use(express.urlencoded());
 
 app.use('/', routes);
 app.use(cors());

--- a/open_cx_server/package.json
+++ b/open_cx_server/package.json
@@ -7,7 +7,6 @@
     "admin-bro": "^1.4.1",
     "admin-bro-expressjs": "^0.3.0",
     "admin-bro-mongoose": "^0.3.0",
-    "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "eslint-config-airbnb-base": "^14.0.0",


### PR DESCRIPTION
As of express 4.16, express has its own body-parser middleware, and since the project uses express 4.17, why not use it instead of the body-parser module?

Noticed this idea through the following stack overflow answer: https://stackoverflow.com/a/12008719

Source: https://expressjs.com/en/changelog/4x.html#4.16.0